### PR TITLE
Properly load data on big screens when changing node

### DIFF
--- a/src/NodeDetails.test.js
+++ b/src/NodeDetails.test.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { configure, shallow } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 
 import NodeDetails, {
   Message,
   MessageGroups,
-  MessageList
+  MessageList,
 } from "./NodeDetails";
 import Loader from "./Loader";
 import { fetchDetails } from "./api";
@@ -19,26 +19,31 @@ jest.mock("./checks");
 describe("NodeDetails", () => {
   it("should convert server response to list of statuses", async () => {
     const fakeData = [{ status: "0x941" }];
-    fetchDetails.mockReturnValue(Promise.resolve(fakeData));
+    fetchDetails.mockResolvedValueOnce(fakeData);
     checkAll.mockReturnValue([{ type: "error", name: "test-status" }]);
 
-    const wrapper = shallow(
-      <NodeDetails match={{ params: { nodeId: "My Node" } }} />
-    );
+    let wrapper;
+
+    await act(async () => {
+      wrapper = mount(
+        <MemoryRouter>
+          <NodeDetails match={{ params: { nodeId: "My Node" } }} />
+        </MemoryRouter>
+      );
+    });
 
     expect(wrapper.find(Loader).length).toBe(1);
     expect(wrapper.find(MessageGroups).length).toBe(0);
 
-    await wrapper.instance().componentDidMount();
-    wrapper.update();
+    await wrapper.update();
 
     const expectedProps = {
       displayMessages: {
         info: [],
         warning: [],
         critical: [],
-        error: [{ type: "error", name: "test-status" }]
-      }
+        error: [{ type: "error", name: "test-status" }],
+      },
     };
     expect(wrapper.find(Loader).length).toBe(0);
     expect(wrapper.find(MessageGroups).length).toBe(1);
@@ -68,16 +73,17 @@ describe("MessageList", () => {
   });
 });
 
-import Error from "@material-ui/icons/Error"
-import Warning from "@material-ui/icons/Warning"
+import Error from "@material-ui/icons/Error";
+import Warning from "@material-ui/icons/Warning";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
 
 describe("Message", () => {
   it("should render", async () => {
     const status = { type: "error", message: "something is really wrong" };
     const wrapper = shallow(<Message status={status} />);
-    expect(wrapper.contains(<Error style={{ fill: "#FF4136" }}/>)).toBe(true);
+    expect(wrapper.contains(<Error style={{ fill: "#FF4136" }} />)).toBe(true);
     expect(wrapper.contains(<Warning />)).toBe(false);
     expect(wrapper.find("span").text()).toBe("something is really wrong");
   });
 });
-


### PR DESCRIPTION
Previously, the app would only fetch the new data on component mount.
Since the `NodeDetails` component is not re-mounted when the screen is
big enough (it will always be in view), it would not get updated props.

This commit converts the component to a functional component and then
adds a `useEffect` that will react to any changes in the `match` prop
provided by react-router.